### PR TITLE
[PR for #104] Make Ruby 3.0.2 the default Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes marked as **(Internal)** deal with refactoring or development setup. Iss
 1. [#98](../../issues/98): Add Ruby 3.0.2.
 1. [#100](../../issues/100): Remove Ruby 3.0.1.
 1. [#102](../../issues/102): Add Ruby 2.7.4.
+1. [#104](../../issues/104): Make Ruby 3.0.2 the default Ruby.
 
 ## 3.3.0 (Jul 11, 2021)
 

--- a/build_scripts/setup_rvm_rubies
+++ b/build_scripts/setup_rvm_rubies
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # The first version in the list will be set as the default Ruby in RVM.
-RUBIES_TO_INSTALL = ['2.7.4', '2.7.3', '3.0.2', '2.6.7']
+RUBIES_TO_INSTALL = ['3.0.2', '2.7.4', '2.7.3', '2.6.7']
 BUNDLER_TO_INSTALL = '2.2.23'
 RUBYGEMS_TO_INSTALL = '3.2.23'
 


### PR DESCRIPTION
Closes #104 